### PR TITLE
fix: access-log-omit-empty-values

### DIFF
--- a/internal/envoy/v3/accesslog.go
+++ b/internal/envoy/v3/accesslog.go
@@ -99,7 +99,8 @@ func FileAccessLogJSON(path string, fields contour_api_v1alpha1.AccessLogJSONFie
 						Format: &envoy_config_core_v3.SubstitutionFormatString_JsonFormat{
 							JsonFormat: jsonformat,
 						},
-						Formatters: extensionConfig(extensions),
+						OmitEmptyValues: true,
+						Formatters:      extensionConfig(extensions),
 					},
 				},
 			}),


### PR DESCRIPTION
This pull request fixes the issue of envoy logs containing null values for some fields.
The solution is to use the omit_empty_values option in the envoy log configuration, which prevents logging fields that have null or empty values.