### PR TITLE
fix: access-log-omit-empty-values (#2)

### DIFF
--- a/internal/envoy/v3/accesslog.go
+++ b/internal/envoy/v3/accesslog.go
@@ -99,7 +99,8 @@ func FileAccessLogJSON(path string, fields contour_api_v1alpha1.AccessLogJSONFie
 						Format: &envoy_config_core_v3.SubstitutionFormatString_JsonFormat{
 							JsonFormat: jsonformat,
 						},
-						Formatters: extensionConfig(extensions),
+						OmitEmptyValues: true,
+						Formatters:      extensionConfig(extensions),
 					},
 				},
 			}),

--- a/internal/envoy/v3/accesslog_test.go
+++ b/internal/envoy/v3/accesslog_test.go
@@ -121,6 +121,7 @@ func TestJSONFileAccessLog(t *testing.T) {
 						Path: "/dev/stdout",
 						AccessLogFormat: &envoy_file_v3.FileAccessLog_LogFormat{
 							LogFormat: &envoy_config_core_v3.SubstitutionFormatString{
+								OmitEmptyValues: true,
 								Format: &envoy_config_core_v3.SubstitutionFormatString_JsonFormat{
 									JsonFormat: &structpb.Struct{
 										Fields: map[string]*structpb.Value{
@@ -151,6 +152,7 @@ func TestJSONFileAccessLog(t *testing.T) {
 						Path: "/dev/stdout",
 						AccessLogFormat: &envoy_file_v3.FileAccessLog_LogFormat{
 							LogFormat: &envoy_config_core_v3.SubstitutionFormatString{
+								OmitEmptyValues: true,
 								Format: &envoy_config_core_v3.SubstitutionFormatString_JsonFormat{
 									JsonFormat: &structpb.Struct{
 										Fields: map[string]*structpb.Value{
@@ -244,6 +246,7 @@ func TestAccessLogLevel(t *testing.T) {
 				Path: "/dev/stdout",
 				AccessLogFormat: &envoy_file_v3.FileAccessLog_LogFormat{
 					LogFormat: &envoy_config_core_v3.SubstitutionFormatString{
+						OmitEmptyValues: true,
 						Format: &envoy_config_core_v3.SubstitutionFormatString_JsonFormat{
 							JsonFormat: &structpb.Struct{
 								Fields: map[string]*structpb.Value{},


### PR DESCRIPTION
This pull request fixes the issue of envoy logs containing null values for some fields.
The solution is to use the omit_empty_values option in the envoy log configuration, which prevents logging fields that have null or empty values.