### PR TITLE
feat: add http support to authz filter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,7 @@ container: ## Build the Contour container image
 		--build-arg "BUILD_GOEXPERIMENT=$(BUILD_GOEXPERIMENT)" \
 		$(DOCKER_BUILD_LABELS) \
 		$(shell pwd) \
+		--platform linux/amd64 \
 		--tag $(IMAGE):$(VERSION)
 
 push: ## Push the Contour container image to the Docker registry

--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -229,7 +229,6 @@ type ExtensionServiceReference struct {
 }
 
 // AuthorizationServiceType is an alias to enforce validation
-// +kubebuilder:validation:Enum=grpc;http
 type AuthorizationServiceAPIType string
 
 const (
@@ -251,6 +250,8 @@ type AuthorizationServer struct {
 	// or a gRPC authorization server.
 	//
 	// +optional
+	// +kubebuilder:validation:Enum=http;grpc
+	// +kubebuilder:default=grpc
 	ServiceAPIType AuthorizationServiceAPIType `json:"serviceAPIType,omitempty"`
 
 	// ServerURI sets the URI of the external HTTP authorization server to which authorization requests must be sent.

--- a/apis/projectcontour/v1/httpproxy.go
+++ b/apis/projectcontour/v1/httpproxy.go
@@ -228,6 +228,15 @@ type ExtensionServiceReference struct {
 	Name string `json:"name,omitempty" protobuf:"bytes,3,opt,name=name"`
 }
 
+// AuthorizationServiceType is an alias to enforce validation
+// +kubebuilder:validation:Enum=grpc;http
+type AuthorizationServiceAPIType string
+
+const (
+	AuthorizationGRPCService AuthorizationServiceAPIType = "grpc"
+	AuthorizationHTTPService AuthorizationServiceAPIType = "http"
+)
+
 // AuthorizationServer configures an external server to authenticate
 // client requests. The external server must implement the v3 Envoy
 // external authorization GRPC protocol (https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/external_auth.proto).
@@ -236,6 +245,18 @@ type AuthorizationServer struct {
 	//
 	// +optional
 	ExtensionServiceRef ExtensionServiceReference `json:"extensionRef,omitempty"`
+
+	// ServiceAPIType defines the external authorization service API type.
+	// It indicates the protocol implemented by the external server, specifying whether it's a raw HTTP authorization server
+	// or a gRPC authorization server.
+	//
+	// +optional
+	ServiceAPIType AuthorizationServiceAPIType `json:"serviceAPIType,omitempty"`
+
+	// ServerURI sets the URI of the external HTTP authorization server to which authorization requests must be sent.
+	// Only required for http services.
+	// +optional
+	ServerURI string `json:"serverURI,omitempty"`
 
 	// AuthPolicy sets a default authorization policy for client requests.
 	// This policy will be used unless overridden by individual routes.

--- a/apis/projectcontour/v1alpha1/extensionservice.go
+++ b/apis/projectcontour/v1alpha1/extensionservice.go
@@ -80,7 +80,7 @@ type ExtensionServiceSpec struct {
 	// Values may be h2 or h2c. If omitted, protocol-selection falls back on Service annotations.
 	//
 	// +optional
-	// +kubebuilder:validation:Enum=h1,h2;h2c
+	// +kubebuilder:validation:Enum=h1;h2;h2c
 	Protocol *string `json:"protocol,omitempty"`
 
 	// The policy for load balancing GRPC service requests. Note that the

--- a/apis/projectcontour/v1alpha1/extensionservice.go
+++ b/apis/projectcontour/v1alpha1/extensionservice.go
@@ -80,7 +80,7 @@ type ExtensionServiceSpec struct {
 	// Values may be h2 or h2c. If omitted, protocol-selection falls back on Service annotations.
 	//
 	// +optional
-	// +kubebuilder:validation:Enum=h2;h2c
+	// +kubebuilder:validation:Enum=h1,h2;h2c
 	Protocol *string `json:"protocol,omitempty"`
 
 	// The policy for load balancing GRPC service requests. Note that the

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -640,6 +640,21 @@ spec:
                       timeout.
                     pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
                     type: string
+                  serverURI:
+                    description: ServerURI sets the URI of the external HTTP authorization
+                      server to which authorization requests must be sent. Only required
+                      for http services.
+                    type: string
+                  serviceAPIType:
+                    default: grpc
+                    description: ServiceAPIType defines the external authorization
+                      service API type. It indicates the protocol implemented by the
+                      external server, specifying whether it's a raw HTTP authorization
+                      server or a gRPC authorization server.
+                    enum:
+                    - http
+                    - grpc
+                    type: string
                   withRequestBody:
                     description: WithRequestBody specifies configuration for sending
                       the client request's body to authorization server.
@@ -4300,6 +4315,21 @@ spec:
                           no timeout.
                         pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
                         type: string
+                      serverURI:
+                        description: ServerURI sets the URI of the external HTTP authorization
+                          server to which authorization requests must be sent. Only
+                          required for http services.
+                        type: string
+                      serviceAPIType:
+                        default: grpc
+                        description: ServiceAPIType defines the external authorization
+                          service API type. It indicates the protocol implemented
+                          by the external server, specifying whether it's a raw HTTP
+                          authorization server or a gRPC authorization server.
+                        enum:
+                        - http
+                        - grpc
+                        type: string
                       withRequestBody:
                         description: WithRequestBody specifies configuration for sending
                           the client request's body to authorization server.
@@ -4961,6 +4991,7 @@ spec:
                   used to reach this Service. Values may be h2 or h2c. If omitted,
                   protocol-selection falls back on Service annotations.
                 enum:
+                - h1
                 - h2
                 - h2c
                 type: string
@@ -7223,6 +7254,21 @@ spec:
                           "h". The string "infinity" is also a valid input and specifies
                           no timeout.
                         pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                        type: string
+                      serverURI:
+                        description: ServerURI sets the URI of the external HTTP authorization
+                          server to which authorization requests must be sent. Only
+                          required for http services.
+                        type: string
+                      serviceAPIType:
+                        default: grpc
+                        description: ServiceAPIType defines the external authorization
+                          service API type. It indicates the protocol implemented
+                          by the external server, specifying whether it's a raw HTTP
+                          authorization server or a gRPC authorization server.
+                        enum:
+                        - http
+                        - grpc
                         type: string
                       withRequestBody:
                         description: WithRequestBody specifies configuration for sending

--- a/examples/contour/01-crds.yaml
+++ b/examples/contour/01-crds.yaml
@@ -631,6 +631,91 @@ spec:
                       intended for use only while migrating applications from internal
                       authorization to Contour external authorization.
                     type: boolean
+                  httpSettings:
+                    description: HttpAuthorizationServerSettings defines configurations
+                      for interacting with an external HTTP authorization server.
+                    properties:
+                      allowedAuthorizationHeaders:
+                        description: AllowedAuthorizationHeaders specifies client
+                          request headers that will be sent to the authorization server.
+                          Note that in addition to the the user’s supplied matchers,
+                          Host, Method, Path, Content-Length, and Authorization are
+                          additionally included in the list.
+                        items:
+                          description: HttpAuthorizationServerAllowedHeaders specifies
+                            how to conditionally match against allowed headers in
+                            the context of HTTP authorization. It includes options
+                            such as Exact, Prefix, Suffix, Contains, and IgnoreCase
+                            to customize header matching criteria. However, regex
+                            support is intentionally excluded to simplify the user
+                            experience and prevent potential issues. One of Prefix,
+                            Exact, Suffix or Contains must be provided.
+                          properties:
+                            contains:
+                              description: Contains specifies a substring that must
+                                be present in the header name.
+                              type: string
+                            exact:
+                              description: Exact specifies a string that the header
+                                name must be equal to.
+                              type: string
+                            ignoreCase:
+                              description: IgnoreCase specifies that string matching
+                                should be case insensitive. Note that this has no
+                                effect on the Regex parameter.
+                              type: boolean
+                            prefix:
+                              description: Prefix defines a prefix match for the header
+                                name.
+                              type: string
+                            suffix:
+                              description: Suffix defines a suffix match for a header
+                                name.
+                              type: string
+                          type: object
+                        type: array
+                      allowedUpstreamHeaders:
+                        description: AllowedUpstreamHeaders specifies authorization
+                          response headers that will be added to the original client
+                          request. Note that coexistent headers will be overridden.
+                        items:
+                          description: HttpAuthorizationServerAllowedHeaders specifies
+                            how to conditionally match against allowed headers in
+                            the context of HTTP authorization. It includes options
+                            such as Exact, Prefix, Suffix, Contains, and IgnoreCase
+                            to customize header matching criteria. However, regex
+                            support is intentionally excluded to simplify the user
+                            experience and prevent potential issues. One of Prefix,
+                            Exact, Suffix or Contains must be provided.
+                          properties:
+                            contains:
+                              description: Contains specifies a substring that must
+                                be present in the header name.
+                              type: string
+                            exact:
+                              description: Exact specifies a string that the header
+                                name must be equal to.
+                              type: string
+                            ignoreCase:
+                              description: IgnoreCase specifies that string matching
+                                should be case insensitive. Note that this has no
+                                effect on the Regex parameter.
+                              type: boolean
+                            prefix:
+                              description: Prefix defines a prefix match for the header
+                                name.
+                              type: string
+                            suffix:
+                              description: Suffix defines a suffix match for a header
+                                name.
+                              type: string
+                          type: object
+                        type: array
+                      pathPrefix:
+                        description: PathPrefix Sets a prefix to the value of authorization
+                          request header Path.
+                        type: string
+                    type: object
                   responseTimeout:
                     description: ResponseTimeout configures maximum time to wait for
                       a check response from the authorization server. Timeout durations
@@ -639,11 +724,6 @@ spec:
                       The string "infinity" is also a valid input and specifies no
                       timeout.
                     pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
-                    type: string
-                  serverURI:
-                    description: ServerURI sets the URI of the external HTTP authorization
-                      server to which authorization requests must be sent. Only required
-                      for http services.
                     type: string
                   serviceAPIType:
                     default: grpc
@@ -4306,6 +4386,94 @@ spec:
                           It is intended for use only while migrating applications
                           from internal authorization to Contour external authorization.
                         type: boolean
+                      httpSettings:
+                        description: HttpAuthorizationServerSettings defines configurations
+                          for interacting with an external HTTP authorization server.
+                        properties:
+                          allowedAuthorizationHeaders:
+                            description: AllowedAuthorizationHeaders specifies client
+                              request headers that will be sent to the authorization
+                              server. Note that in addition to the the user’s supplied
+                              matchers, Host, Method, Path, Content-Length, and Authorization
+                              are additionally included in the list.
+                            items:
+                              description: HttpAuthorizationServerAllowedHeaders specifies
+                                how to conditionally match against allowed headers
+                                in the context of HTTP authorization. It includes
+                                options such as Exact, Prefix, Suffix, Contains, and
+                                IgnoreCase to customize header matching criteria.
+                                However, regex support is intentionally excluded to
+                                simplify the user experience and prevent potential
+                                issues. One of Prefix, Exact, Suffix or Contains must
+                                be provided.
+                              properties:
+                                contains:
+                                  description: Contains specifies a substring that
+                                    must be present in the header name.
+                                  type: string
+                                exact:
+                                  description: Exact specifies a string that the header
+                                    name must be equal to.
+                                  type: string
+                                ignoreCase:
+                                  description: IgnoreCase specifies that string matching
+                                    should be case insensitive. Note that this has
+                                    no effect on the Regex parameter.
+                                  type: boolean
+                                prefix:
+                                  description: Prefix defines a prefix match for the
+                                    header name.
+                                  type: string
+                                suffix:
+                                  description: Suffix defines a suffix match for a
+                                    header name.
+                                  type: string
+                              type: object
+                            type: array
+                          allowedUpstreamHeaders:
+                            description: AllowedUpstreamHeaders specifies authorization
+                              response headers that will be added to the original
+                              client request. Note that coexistent headers will be
+                              overridden.
+                            items:
+                              description: HttpAuthorizationServerAllowedHeaders specifies
+                                how to conditionally match against allowed headers
+                                in the context of HTTP authorization. It includes
+                                options such as Exact, Prefix, Suffix, Contains, and
+                                IgnoreCase to customize header matching criteria.
+                                However, regex support is intentionally excluded to
+                                simplify the user experience and prevent potential
+                                issues. One of Prefix, Exact, Suffix or Contains must
+                                be provided.
+                              properties:
+                                contains:
+                                  description: Contains specifies a substring that
+                                    must be present in the header name.
+                                  type: string
+                                exact:
+                                  description: Exact specifies a string that the header
+                                    name must be equal to.
+                                  type: string
+                                ignoreCase:
+                                  description: IgnoreCase specifies that string matching
+                                    should be case insensitive. Note that this has
+                                    no effect on the Regex parameter.
+                                  type: boolean
+                                prefix:
+                                  description: Prefix defines a prefix match for the
+                                    header name.
+                                  type: string
+                                suffix:
+                                  description: Suffix defines a suffix match for a
+                                    header name.
+                                  type: string
+                              type: object
+                            type: array
+                          pathPrefix:
+                            description: PathPrefix Sets a prefix to the value of
+                              authorization request header Path.
+                            type: string
+                        type: object
                       responseTimeout:
                         description: ResponseTimeout configures maximum time to wait
                           for a check response from the authorization server. Timeout
@@ -4314,11 +4482,6 @@ spec:
                           "h". The string "infinity" is also a valid input and specifies
                           no timeout.
                         pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
-                        type: string
-                      serverURI:
-                        description: ServerURI sets the URI of the external HTTP authorization
-                          server to which authorization requests must be sent. Only
-                          required for http services.
                         type: string
                       serviceAPIType:
                         default: grpc
@@ -7246,6 +7409,94 @@ spec:
                           It is intended for use only while migrating applications
                           from internal authorization to Contour external authorization.
                         type: boolean
+                      httpSettings:
+                        description: HttpAuthorizationServerSettings defines configurations
+                          for interacting with an external HTTP authorization server.
+                        properties:
+                          allowedAuthorizationHeaders:
+                            description: AllowedAuthorizationHeaders specifies client
+                              request headers that will be sent to the authorization
+                              server. Note that in addition to the the user’s supplied
+                              matchers, Host, Method, Path, Content-Length, and Authorization
+                              are additionally included in the list.
+                            items:
+                              description: HttpAuthorizationServerAllowedHeaders specifies
+                                how to conditionally match against allowed headers
+                                in the context of HTTP authorization. It includes
+                                options such as Exact, Prefix, Suffix, Contains, and
+                                IgnoreCase to customize header matching criteria.
+                                However, regex support is intentionally excluded to
+                                simplify the user experience and prevent potential
+                                issues. One of Prefix, Exact, Suffix or Contains must
+                                be provided.
+                              properties:
+                                contains:
+                                  description: Contains specifies a substring that
+                                    must be present in the header name.
+                                  type: string
+                                exact:
+                                  description: Exact specifies a string that the header
+                                    name must be equal to.
+                                  type: string
+                                ignoreCase:
+                                  description: IgnoreCase specifies that string matching
+                                    should be case insensitive. Note that this has
+                                    no effect on the Regex parameter.
+                                  type: boolean
+                                prefix:
+                                  description: Prefix defines a prefix match for the
+                                    header name.
+                                  type: string
+                                suffix:
+                                  description: Suffix defines a suffix match for a
+                                    header name.
+                                  type: string
+                              type: object
+                            type: array
+                          allowedUpstreamHeaders:
+                            description: AllowedUpstreamHeaders specifies authorization
+                              response headers that will be added to the original
+                              client request. Note that coexistent headers will be
+                              overridden.
+                            items:
+                              description: HttpAuthorizationServerAllowedHeaders specifies
+                                how to conditionally match against allowed headers
+                                in the context of HTTP authorization. It includes
+                                options such as Exact, Prefix, Suffix, Contains, and
+                                IgnoreCase to customize header matching criteria.
+                                However, regex support is intentionally excluded to
+                                simplify the user experience and prevent potential
+                                issues. One of Prefix, Exact, Suffix or Contains must
+                                be provided.
+                              properties:
+                                contains:
+                                  description: Contains specifies a substring that
+                                    must be present in the header name.
+                                  type: string
+                                exact:
+                                  description: Exact specifies a string that the header
+                                    name must be equal to.
+                                  type: string
+                                ignoreCase:
+                                  description: IgnoreCase specifies that string matching
+                                    should be case insensitive. Note that this has
+                                    no effect on the Regex parameter.
+                                  type: boolean
+                                prefix:
+                                  description: Prefix defines a prefix match for the
+                                    header name.
+                                  type: string
+                                suffix:
+                                  description: Suffix defines a suffix match for a
+                                    header name.
+                                  type: string
+                              type: object
+                            type: array
+                          pathPrefix:
+                            description: PathPrefix Sets a prefix to the value of
+                              authorization request header Path.
+                            type: string
+                        type: object
                       responseTimeout:
                         description: ResponseTimeout configures maximum time to wait
                           for a check response from the authorization server. Timeout
@@ -7254,11 +7505,6 @@ spec:
                           "h". The string "infinity" is also a valid input and specifies
                           no timeout.
                         pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
-                        type: string
-                      serverURI:
-                        description: ServerURI sets the URI of the external HTTP authorization
-                          server to which authorization requests must be sent. Only
-                          required for http services.
                         type: string
                       serviceAPIType:
                         default: grpc

--- a/internal/dag/conditions.go
+++ b/internal/dag/conditions.go
@@ -407,6 +407,56 @@ func queryParameterMatchConditionsValid(conditions []contour_api_v1.MatchConditi
 	return nil
 }
 
+// ExternalAuthAllowedHeadersValid validates that the allowed header conditions within a
+// slice of HttpAuthorizationServerAllowedHeaders are valid. Specifically, it returns an error for
+// any of the following scenarios:
+//   - no conditions are set
+//   - more than one condition is set in the same allowed header condition branch
+//   - invalid regular expression is specified for the Regex condition
+func ExternalAuthAllowedHeadersValid(allowedHeaders []contour_api_v1.HttpAuthorizationServerAllowedHeaders) error {
+	for _, allowedHeader := range allowedHeaders {
+		sum := 0
+
+		// To streamline user experience and mitigate potential issues, we do not support regex.
+		// Additionally, it's essential to ensure that any regex patterns adhere to the configured runtime key, re2.max_program_size.error_level
+		// by verifying that the program size is smaller than the specified value.
+		// This necessitates thorough validation of user input.
+		//
+		// if allowedHeader.Regex != "" {
+		// 	if err := ValidateRegex(allowedHeader.Regex); err != nil {
+		// 		return errors.New("the RE2 regex syntax is invalid")
+		// 	}
+		// 	sum++
+		// }
+
+		if allowedHeader.Exact != "" {
+			sum++
+		}
+
+		if allowedHeader.Prefix != "" {
+			sum++
+		}
+
+		if allowedHeader.Suffix != "" {
+			sum++
+		}
+
+		if allowedHeader.Contains != "" {
+			sum++
+		}
+
+		if sum == 0 {
+			return errors.New("one of prefix, suffix, exact or contains is required for each allowedHeader")
+		}
+
+		if sum > 1 {
+			return errors.New("more than one prefix, suffix, exact or contains is not allowed in an allowedHeader")
+		}
+	}
+
+	return nil
+}
+
 // ValidateRegex returns an error if the supplied
 // RE2 regex syntax is invalid.
 func ValidateRegex(regex string) error {

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -859,9 +859,23 @@ type ExternalAuthorization struct {
 	// or a gRPC authorization server.
 	ServiceAPIType contour_api_v1.AuthorizationServiceAPIType
 
-	// ServerURI sets the URI of the external HTTP authorization server to which authorization requests must be sent.
+	// HttpAllowedAuthorizationHeaders specifies client request headers that will be sent to the authorization server.
+	// Note that in addition to the the user’s supplied matchers, Host, Method, Path, Content-Length, and Authorization are additionally included in the list.
+	HttpAllowedAuthorizationHeaders []contour_api_v1.HttpAuthorizationServerAllowedHeaders
+
+	// HttpAllowedUpstreamHeaders specifies authorization response headers that will be added to the original client request.
+	// Note that coexistent headers will be overridden.
+	HttpAllowedUpstreamHeaders []contour_api_v1.HttpAuthorizationServerAllowedHeaders
+
+	// HttpPathPrefix Sets a prefix to the value of authorization request header Path.
+	HttpPathPrefix string
+
+	// Note: This field is not used by Envoy
+	// https://github.com/envoyproxy/envoy/issues/5357
+	//
+	// HttpServerURI sets the URI of the external HTTP authorization server to which authorization requests must be sent.
 	// Only required for http services.
-	ServerURI string
+	// HttpServerURI string
 
 	// AuthorizationResponseTimeout sets how long the proxy should wait
 	// for authorization server responses.

--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -27,6 +27,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	"github.com/projectcontour/contour/internal/status"
 	"github.com/projectcontour/contour/internal/timeout"
 )
@@ -852,6 +853,15 @@ type ExternalAuthorization struct {
 	// requests are forwarded to for authorization. If nil, no
 	// authorization is enabled for this host.
 	AuthorizationService *ExtensionCluster
+
+	// ServiceAPIType defines the external authorization service API type.
+	// It indicates the protocol implemented by the external server, specifying whether it's a raw HTTP authorization server
+	// or a gRPC authorization server.
+	ServiceAPIType contour_api_v1.AuthorizationServiceAPIType
+
+	// ServerURI sets the URI of the external HTTP authorization server to which authorization requests must be sent.
+	// Only required for http services.
+	ServerURI string
 
 	// AuthorizationResponseTimeout sets how long the proxy should wait
 	// for authorization server responses.

--- a/internal/dag/httpproxy_processor.go
+++ b/internal/dag/httpproxy_processor.go
@@ -1375,10 +1375,25 @@ func (p *HTTPProxyProcessor) computeVirtualHostAuthorization(auth *contour_api_v
 		return nil
 	}
 
+	if auth.ServiceAPIType == contour_api_v1.AuthorizationHTTPService && auth.ServerURI == "" {
+		validCond.AddErrorf(contour_api_v1.ConditionTypeAuthError, "AuthBadServerURI",
+			"Spec.Virtualhost.Authorization.ServerURI is not set and it is required for http type")
+
+		return nil
+	}
+
 	globalExternalAuthorization := &ExternalAuthorization{
 		AuthorizationService:         ext,
 		AuthorizationFailOpen:        auth.FailOpen,
 		AuthorizationResponseTimeout: *respTimeout,
+	}
+
+	switch auth.ServiceAPIType {
+	case contour_api_v1.AuthorizationGRPCService:
+		globalExternalAuthorization.ServiceAPIType = contour_api_v1.AuthorizationGRPCService
+	case contour_api_v1.AuthorizationHTTPService:
+		globalExternalAuthorization.ServiceAPIType = contour_api_v1.AuthorizationHTTPService
+		globalExternalAuthorization.ServerURI = auth.ServerURI
 	}
 
 	if auth.WithRequestBody != nil {

--- a/internal/xdscache/v3/listener.go
+++ b/internal/xdscache/v3/listener.go
@@ -22,6 +22,7 @@ import (
 	http "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	envoy_tls_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
+	contour_api_v1 "github.com/projectcontour/contour/apis/projectcontour/v1"
 	contour_api_v1alpha1 "github.com/projectcontour/contour/apis/projectcontour/v1alpha1"
 	"github.com/projectcontour/contour/internal/contour"
 	"github.com/projectcontour/contour/internal/contourconfig"
@@ -195,9 +196,14 @@ type RateLimitConfig struct {
 
 type GlobalExternalAuthConfig struct {
 	ExtensionServiceConfig
-	FailOpen        bool
-	Context         map[string]string
-	WithRequestBody *dag.AuthorizationServerBufferSettings
+	FailOpen                        bool
+	Context                         map[string]string
+	ServiceAPIType                  contour_api_v1.AuthorizationServiceAPIType
+	HttpAllowedAuthorizationHeaders []contour_api_v1.HttpAuthorizationServerAllowedHeaders
+	HttpAllowedUpstreamHeaders      []contour_api_v1.HttpAuthorizationServerAllowedHeaders
+	HttpPathPrefix                  string
+	WithRequestBody                 *dag.AuthorizationServerBufferSettings
+	// HttpServerURI                string
 }
 
 // httpAccessLog returns the access log for the HTTP (non TLS)
@@ -626,6 +632,10 @@ func httpGlobalExternalAuthConfig(config *GlobalExternalAuthConfig) *http.HttpFi
 			Name: dag.ExtensionClusterName(config.ExtensionServiceConfig.ExtensionService),
 			SNI:  config.ExtensionServiceConfig.SNI,
 		},
+		ServiceAPIType:                     config.ServiceAPIType,
+		HttpAllowedAuthorizationHeaders:    config.HttpAllowedAuthorizationHeaders,
+		HttpAllowedUpstreamHeaders:         config.HttpAllowedUpstreamHeaders,
+		HttpPathPrefix:                     config.HttpPathPrefix,
 		AuthorizationFailOpen:              config.FailOpen,
 		AuthorizationResponseTimeout:       config.ExtensionServiceConfig.Timeout,
 		AuthorizationServerWithRequestBody: config.WithRequestBody,


### PR DESCRIPTION
Envoy external authorization filter calls an external gRPC or HTTP service to check whether an incoming HTTP request is authorized or not. Contour only supports configuring gRPC services through its CRDs at this time. This PR adds support for HTTP services too.

This change is backward compatible.

https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/ext_authz_filter